### PR TITLE
Limit max extra life to 5

### DIFF
--- a/invasores.txt
+++ b/invasores.txt
@@ -119,4 +119,7 @@ I need to create a PDF document for Eric and the gallery with instructions for i
 My son productively broke the game. When the invaders overrun the player, but the player can dodge them, then the game continues without a "game over". My son is clever and figured out how to fix this. We created a new branch to implement the changes.
 
 ====
+2024 05 25
+Added a line to ui.py at line number 76 to address too many lives accumulated
+
 end of file

--- a/ui.py
+++ b/ui.py
@@ -73,7 +73,7 @@ class LifeCounter:
             rect.left, rect.top = (rect.left + LIFE_POS_SHIFT[0] + rect.w, rect.top + LIFE_POS_SHIFT[1])
 
     def one_up(self):
-        if self.life_count < 7: #added this condition to prevent crash from accumulating too many lives
+        if self.life_count < 5: #added this condition to prevent crash from accumulating too many lives
             self.life_count += 1
             self.life_gain_count += 1
             self.one_life_up_sound.play()

--- a/ui.py
+++ b/ui.py
@@ -73,9 +73,10 @@ class LifeCounter:
             rect.left, rect.top = (rect.left + LIFE_POS_SHIFT[0] + rect.w, rect.top + LIFE_POS_SHIFT[1])
 
     def one_up(self):
-        self.life_count += 1
-        self.life_gain_count += 1
-        self.one_life_up_sound.play()
+        if self.life_count < 7: #added this condition to prevent crash from accumulating too many lives
+            self.life_count += 1
+            self.life_gain_count += 1
+            self.one_life_up_sound.play()
 
 
 class GameOver:


### PR DESCRIPTION
Address known issue that accumulating 10+ extra lives causes game to crash by adding a conditional test at line 76 of ui.py such that if value of lives is less than 5 (or any other given number less than 10 to adjust difficulty of gameplay) then an earned extra life can be added. This fix has been field tested in exhibition context January-February 2025. The question of why accumulating more than 10 lives causes a crash has not been addressed.